### PR TITLE
fix: 盗難システムと時間経過システムの統一

### DIFF
--- a/Assets/Project/Scripts/GlobalGameManager.cs
+++ b/Assets/Project/Scripts/GlobalGameManager.cs
@@ -40,6 +40,11 @@ public class GlobalGameManager : MonoBehaviour
     {
         Debug.Log("盗難システムを開始します");
 
+        if (TimeManager.Instance != null)
+        {
+            TimeManager.Instance.isTimeStopped = true;
+        }
+
         currentDay++;
         Debug.Log("Day " + currentDay);
 
@@ -120,6 +125,11 @@ public class GlobalGameManager : MonoBehaviour
         }
 
         yield return new WaitForSeconds(5.0f);
+
+        if (TimeManager.Instance != null)
+        {
+            TimeManager.Instance.Sleep();
+        }
 
         isMorning = true;
         GameData.lastExitDirection = "Workshop";

--- a/Assets/Project/Scripts/Time/TimeManager.cs
+++ b/Assets/Project/Scripts/Time/TimeManager.cs
@@ -60,6 +60,6 @@ public class TimeManager : MonoBehaviour
     {
         currentTime = 0f;
         isTimeStopped = false;
-        Debug.Log("【TimeManager】起床！新しい一日が始まりました。");
+        Debug.Log($"【TimeManager】リセット完了: Day {GlobalGameManager.Instance.currentDay} 開始");
     }
 }


### PR DESCRIPTION
## 概要
日をまたぐ際に時間が正しくリセットされない問題、および睡眠演出中（暗転・ログ表示中）に時間が経過し続けてしまう問題を修正しました。これに合わせ、`TimeManager` と `GlobalGameManager` の連携を強化しました。

## 関連Issue
- #51

## 変更点

### 🛠 システム・ロジックの修正
- **`GlobalGameManager.cs`**
  - `SleepCoroutine` の開始時に `TimeManager.Instance.isTimeStopped = true` を設定するようにしました。これにより、睡眠中のフェード演出やログ表示の数秒間が「翌朝の時間」として消費されるのを防ぎます。
  - シーン遷移（`SceneManager.LoadScene`）の直前に `TimeManager.Instance.Sleep()` を呼び出すようにしました。これにより、翌朝開始時に必ず `currentTime` が 0（0:00）からリセットされ、停止フラグも解除されます。

- **`TimeManager.cs`**
  - `Sleep()` メソッドが呼ばれた際に、デバッグログでリセットされた日付を表示するようログ出力を強化しました。

## 動作確認手順
1. `Level1_Village` シーンで20時（停止時間）まで待機、またはベッドで睡眠を開始する。
2. 睡眠演出（暗転とログ表示）が終了し、翌日のシーンへ遷移するのを確認する。
3. 遷移後の `Day 2` において、`TimeManager` の `currentTime` が 0 からカウントを開始していることを確認する。
4. Unityコンソールに `【TimeManager】リセット完了: Day 2 開始` と表示されていることを確認する。

## 補足
- この修正により、放置による日またぎや、演出時間の食い込みといった時間管理上の不整合が解消されました。

close #51 